### PR TITLE
Bump kotlin.version from 1.8.22 to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.8.22</kotlin.version>
+        <kotlin.version>1.9.0</kotlin.version>
         <mainClass>fr.jais.scraper.ScraperKt</mainClass>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
     </properties>


### PR DESCRIPTION
Bumps `kotlin.version` from 1.8.22 to 1.9.0.

Updates `kotlin-test-junit5` from 1.8.22 to 1.9.0
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/commits)

Updates `kotlin-stdlib-jdk8` from 1.8.22 to 1.9.0
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/master/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/commits)

Updates `kotlin-maven-plugin` from 1.8.22 to 1.9.0

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin:kotlin-test-junit5 dependency-type: direct:development update-type: version-update:semver-minor
- dependency-name: org.jetbrains.kotlin:kotlin-stdlib-jdk8 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.jetbrains.kotlin:kotlin-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...